### PR TITLE
fix: preserve leading zeros in testdata filenames during natural sort

### DIFF
--- a/lib/judger.js
+++ b/lib/judger.js
@@ -23,15 +23,19 @@ function generateRandomString(length) {
 
 function splitByDigitsAndNonDigits(input) {
   const segments = input.split(/(\d+)/).filter(Boolean);
-  return segments.map(segment => /^\d+$/.test(segment) ? Number(segment) : segment);
+  return segments.map(segment => /^\d+$/.test(segment)
+    ? { __n: parseInt(segment, 10), __s: segment }
+    : segment);
 }
 
 function customSort(a, b) {
-  if (typeof a === 'number' && typeof b === 'number') {
-      return a - b;
-  } else if (typeof a === 'string' && typeof b === 'string') {
-      return a.localeCompare(b);
-  } else if (typeof a === 'number') {
+  const va = (a != null && typeof a === 'object') ? a.__n : a;
+  const vb = (b != null && typeof b === 'object') ? b.__n : b;
+  if (typeof va === 'number' && typeof vb === 'number') {
+      return va - vb;
+  } else if (typeof va === 'string' && typeof vb === 'string') {
+      return va.localeCompare(vb);
+  } else if (typeof va === 'number') {
       return -1;
   } else {
       return 1;
@@ -119,7 +123,9 @@ async function judger(file, data, options) {
         }
         dataList = dataList.map(data => splitByDigitsAndNonDigits(data));
         dataList.sort(customSort);
-        dataList = dataList.map(data => data.join(''));
+        dataList = dataList.map(data => data.map(s =>
+          (s != null && typeof s === 'object') ? s.__s : s
+        ).join(''));
   
         for (let data of dataList) {
           if (dataList.length > 1) {


### PR DESCRIPTION
## Problem

When testdata filenames contain leading zeros (e.g. `a01.in`, `a02.in`), running Atiro fails because the filename gets mangled to `a1.in` which does not exist.

**Root cause:** In `lib/judger.js`, `splitByDigitsAndNonDigits()` converts digit segments via `Number()`, which strips leading zeros. After sorting, `data.join('')\) extracts `__n` from wrapper objects for comparison
- Final join step unwraps objects back to their raw string form

This preserves natural sort ordering (a1 < a2 < a10) while keeping leading zero padding intact in the resulting filename.